### PR TITLE
Update pyreadline to pyreadline3 dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -336,9 +336,9 @@ python-versions = ">=3.6"
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
-name = "pyreadline"
-version = "2.1"
-description = "A python implmementation of GNU readline."
+name = "pyreadline3"
+version = "3.4.1"
+description = "A python implementation of GNU readline."
 category = "main"
 optional = false
 python-versions = "*"
@@ -642,7 +642,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6,<4"
-content-hash = "e4c113465af812c89fd6c8e192fd3b87a2143397e52dc70d6ac32382cfcd5cd9"
+content-hash = "9768c4190ae8a42ebaa88613bd8e3c05ebc584b1affbb7128dd3fc346361e0e1"
 
 [metadata.files]
 alabaster = [
@@ -915,10 +915,9 @@ pyparsing = [
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
     {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
 ]
-pyreadline = [
-    {file = "pyreadline-2.1.win-amd64.exe", hash = "sha256:9ce5fa65b8992dfa373bddc5b6e0864ead8f291c94fbfec05fbd5c836162e67b"},
-    {file = "pyreadline-2.1.win32.exe", hash = "sha256:65540c21bfe14405a3a77e4c085ecfce88724743a4ead47c66b84defcf82c32e"},
-    {file = "pyreadline-2.1.zip", hash = "sha256:4530592fc2e85b25b1a9f79664433da09237c1a270e4d78ea5aa3a2c7229e2d1"},
+pyreadline3 = [
+    {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
+    {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
 ]
 pytest = [
     {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.6,<4"
-pyreadline = {version = "^2.1", markers = "sys_platform == 'win32'"}
 windows-curses = {version = "^2.3.0", markers = "sys_platform == 'win32'"}
+pyreadline3 = {version = "^3.4.1", platform = "win32"}
 
 [tool.poetry.dev-dependencies]
 pudb = "^2022.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.6,<4"
 windows-curses = {version = "^2.3.0", markers = "sys_platform == 'win32'"}
-pyreadline3 = {version = "^3.4.1", platform = "win32"}
+pyreadline3 = {version = "^3.4.1", markers = "sys_platform == 'win32'"}
 
 [tool.poetry.dev-dependencies]
 pudb = "^2022.1.1"


### PR DESCRIPTION
Fixes bug when recline is installed in python 3.10+

[recline-2022.6-py3-none-any.zip](https://github.com/NetApp/recline/files/9066170/recline-2022.6-py3-none-any.zip)
