### PR TITLE
Fix for Empty except

### DIFF
--- a/recline/repl/shell.py
+++ b/recline/repl/shell.py
@@ -206,8 +206,7 @@ def _setup_repl(program_name: str, prompt: str, history_file: str, argv: List[st
         try:
             _run_command(commands.START_COMMAND, argv[1:])
         except CommandBackgrounded:
-            # START_COMMAND may intentionally run in background; no foreground follow-up needed here.
-            # START_COMMAND may intentionally run in background; no foreground follow-up needed here.
+            # START_COMMAND may run in the background intentionally; nothing more to do here.
             pass
 
 

--- a/recline/repl/shell.py
+++ b/recline/repl/shell.py
@@ -207,6 +207,7 @@ def _setup_repl(program_name: str, prompt: str, history_file: str, argv: List[st
             _run_command(commands.START_COMMAND, argv[1:])
         except CommandBackgrounded:
             # START_COMMAND may intentionally run in background; no foreground follow-up needed here.
+            # START_COMMAND may intentionally run in background; no foreground follow-up needed here.
             pass
 
 

--- a/recline/repl/shell.py
+++ b/recline/repl/shell.py
@@ -206,6 +206,7 @@ def _setup_repl(program_name: str, prompt: str, history_file: str, argv: List[st
         try:
             _run_command(commands.START_COMMAND, argv[1:])
         except CommandBackgrounded:
+            # START_COMMAND may intentionally run in background; no foreground follow-up needed here.
             pass
 
 


### PR DESCRIPTION
To fix this without changing functionality, keep catching `CommandBackgrounded` but document why it is intentionally ignored in this call site.

Best single change:
- In `recline/repl/shell.py`, in `_setup_repl(...)`, update the `except CommandBackgrounded:` block under `if commands.START_COMMAND:` so it includes an explanatory comment before `pass`.

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._