### PR TITLE
Fix for Empty except

### DIFF
--- a/recline/repl/shell.py
+++ b/recline/repl/shell.py
@@ -240,6 +240,7 @@ def track_command_history(filename: str) -> None:
         # default history len is -1 (infinite), which may grow unruly
         readline.set_history_length(1000)
     except IOError:
+        # Missing/unreadable history file is non-fatal (e.g., first run); continue.
         pass
     atexit.register(readline.write_history_file, filename)
 


### PR DESCRIPTION
The best fix is to keep the existing behavior (do not fail startup when history cannot be read) but add an explanatory comment inside the `except IOError:` block so the intentional swallow is documented.

In `recline/repl/shell.py`, update the `track_command_history` function around lines 242–243:

- Keep `except IOError:` as-is.
- Replace bare `pass` with a brief comment explaining expected scenarios (e.g., history file missing/unreadable on first run) and then `pass`.

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._