### PR TITLE
Fix for Empty except

### DIFF
--- a/recline/arg_types/choices.py
+++ b/recline/arg_types/choices.py
@@ -77,10 +77,8 @@ class Choices(ReclineType):
                     return None
 
                 current_choices = self.__class__.available_choices
-                try:
-                    current_choices = self.__class__.available_choices()
-                except TypeError:
-                    pass
+                if callable(current_choices):
+                    current_choices = current_choices()
 
                 current_choices = [str(c) for c in current_choices]
                 if cache_choices:


### PR DESCRIPTION
The best fix is to replace the `try/except TypeError: pass` logic with an explicit `callable(...)` check before invoking `available_choices`. This preserves behavior (support both static list and callable) while removing the empty `except` and preventing accidental suppression of real `TypeError`s thrown by a callable implementation.

In `recline/arg_types/choices.py`, inside `_Choices.choices` (around lines 79–83), update the code so that:
- `current_choices` is initialized from `self.__class__.available_choices` as it is now.
- Only call it when it is callable.
- Remove the empty `except TypeError` block entirely.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._