### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/recline/arg_types/ranged_int.py
+++ b/recline/arg_types/ranged_int.py
@@ -48,8 +48,6 @@ class RangedInt(ReclineType):
         max_val = max
 
         class _RangedInt(RangedInt):
-            metavar = '<int>'
-
             range_str = ''
             if min_val is not None and max_val is not None:
                 range_str = '{%s-%s}' % (min_val, max_val)


### PR DESCRIPTION
The general fix is to remove assignments that are overwritten before use, keeping only the assignment that is actually consumed.

Best fix here: in `recline/arg_types/ranged_int.py`, inside nested class `_RangedInt` in `RangedInt.define`, delete the initial `metavar = '<int>'` assignment and keep the final computed assignment `metavar = f'<int{range_str}>'`. This preserves runtime behavior exactly because the second assignment is unconditional and already determines the final class attribute value.

No imports, new methods, or new definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._